### PR TITLE
CLI that prints version info with -v

### DIFF
--- a/cli/psychic-octo-robot.js
+++ b/cli/psychic-octo-robot.js
@@ -1,0 +1,33 @@
+/**
+ * Created by Devon Timaeus on 9/24/2014.
+ */
+
+var program = require("commander");
+
+program
+    .version('0.0.1')
+    .option('-v, --versionFull', 'Print out all the version info for the CLI')
+    .option('-l, --libraries', 'Print out the versions of the libraries used');
+
+program._name = 'psychic-octo-robot';
+program.on('version', function(){
+    console.log("browserify: "          + "5.11.2");
+});
+
+// This just pulls out the first 2 arguments as they should be
+// the path to the script as well as the script name itself
+var args = process.argv.slice(2);
+
+if (args.length == 0){
+    console.log("No arguments provided");
+    program.help();
+}
+
+program.parse(process.argv);
+
+if (program.versionFull) {
+    console.log("psychic-octo-robot: "   + program._version);
+    console.log("browserify: "          + "5.11.2");
+    console.log("js-git: "              + "0.7.7");
+    console.log("commander.js: "        + "2.3.0");
+}


### PR DESCRIPTION
added the beginnings of a cli, for now it just can print version information

From what I could tell, this is really all that was needed for the issue that was related to this
[https://github.com/PolicyStat/psychic-octo-robot/issues/2]

I was thinking that there should be tests to check that this works, but there is little actual _work_ being done, so not much that is testable, just printing out stuff I get from function calls really.
If there is more that should be done, or if anything else is needed, just let me know, but I think this is done.

I used commander.js to make the option parsing nice, they use an MIT license so license stuff should be fine.
closes #2 
