### PR TITLE
Get output of Git diff commands for later use

### DIFF
--- a/cli/diffParser.js
+++ b/cli/diffParser.js
@@ -12,18 +12,9 @@ function getDiff(repoLocation) {
     var resolvedRepoLocation = path.resolve(repoLocation);
     process.chdir(resolvedRepoLocation);
 
-    var command = "git --no-pager diff HEAD HEAD^ > patch_file";
-    console.log(command);
-    var other = shellTools.shellOut(command);
-    other = require('simple-git')().diff('HEAD^ HEAD');
-    console.log("Other: " + other);
-    var patchFileLocation = path.join(resolvedRepoLocation, 'patch_file');
-    console.log("patchFileLocation: " + patchFileLocation);
-    var diffOutput = fs.readFileSync(patchFileLocation, 'utf-8');
-//    fs.unlinkSync(patchFileLocation);
-    var otherOutput = shellTools.shellOut("git log");
-    console.log(diffOutput);
-    console.log(otherOutput);
+    var command = 'git --no-pager diff HEAD^';
+    var diffOutput = shellTools.shellOut(command);
+//    console.log("output of the command is: " + diffOutput);
     process.chdir(startingLocation);
     return diffOutput;
 }

--- a/cli/psychic-octo-robot.js
+++ b/cli/psychic-octo-robot.js
@@ -23,7 +23,7 @@ program
 
 program
     .command('init <file> <outputPath> <repoName>')
-    .description('Initialize a Repository for the given file')
+    .description('\n\tInitialize a Repository for the given file')
     .action(function(file, outputPath, repoName) {
         init.initializeRepository(file, outputPath, repoName);
         printExtraHelp();
@@ -31,21 +31,21 @@ program
 
 program
     .command('commit <file> <pathToRepository> <commitMessage>')
-    .description('Commit to a Repository with the given file')
+    .description('\n\tCommit to a Repository with the given file')
     .action(function(file, pathToRepository, commitMessage) {
         init.commitDocument(file, pathToRepository, './', commitMessage);
     });
 
 program
     .command('write <directory> <outputFile>')
-    .description('Convert a Repository into an HTML file')
+    .description('\n\tConvert a Repository into an HTML file')
     .action(function(directory, outputFile) {
         writer.generateFile(directory, outputFile);
     });
 
 program
     .command('diff <directory>')
-    .description('Show the difference between the last 2 revisions of the repository')
+    .description('\n\tShow the difference between the last 2 revisions of the repository')
     .action(function(directory) {
         init.getDiff(directory);
     });

--- a/cli/repoInit.js
+++ b/cli/repoInit.js
@@ -79,7 +79,6 @@ function getDiff(repoLocation) {
             throw new URIError("Directory does not exist at location: " + repoLocation);
         }
         var diffOutput = diffParser.getDiff(repoLocation);
-        console.log(diffOutput);
     } catch (err) {
         if (err instanceof URIError) {
             console.error(err.message);


### PR DESCRIPTION
Fixed the git diff command so now it works & gets the output for later use, since we're abandoning Windows support, not much has changed, but this works now